### PR TITLE
Made the nested diagnostics messages clicks go to proper places

### DIFF
--- a/c-cpp-flylint-server/src/linters/clang.ts
+++ b/c-cpp-flylint-server/src/linters/clang.ts
@@ -27,9 +27,6 @@ export class Clang extends Linter {
     }
 
     protected resetParser() {
-        this.fileName = new Array<String>(0);
-        this.lineNumber = new Array<Number>(0);
-        this.messages = new Array<String>(0);
         this.actualFileName = "";
         this.tmpFileName = "";
     }
@@ -131,36 +128,29 @@ export class Clang extends Linter {
         let inFileRegex = /^In file included from (.+?):([0-9]+):/;
 
         if ((inFileArray = inFileRegex.exec(line)) != null) {
-            this.fileName.push(inFileArray[1] == this.tmpFileName ? this.actualFileName : inFileArray[1]);
-            this.lineNumber.push(parseInt(inFileArray[2]) - 1);
-            this.messages.push(line.replace(
-                new RegExp(this.tmpFileName.toString()),
-                this.actualFileName.toString()));
-            return {};
+            let result = {
+                fileName: (inFileArray[1] == this.tmpFileName ? this.actualFileName : inFileArray[1]),
+                line: parseInt(inFileArray[2]) - 1,
+                column: 0,
+                severity: 'Warning',
+                code: 0,
+                message: 'Issues in file included from here',
+                source: 'Clang',
+            };
+            // return the resulting diagnostic
+            return result;
         }
 
         if ((regexArray = regex.exec(line)) != null) {
-            this.fileName.push(regexArray[1]);
-            this.lineNumber.push(parseInt(regexArray[2]) - 1);
-            if (this.messages.length == 0) {
-                this.messages.push(regexArray[5]);
-            } else {
-                this.messages.push(line);
-            }
-
             let result = {
-                fileName: this.fileName.shift(),
-                line: this.lineNumber.shift(),
-                column: 0, // FIXME: protocol does not take start+end columns
+                fileName: (regexArray[1] == this.tmpFileName ? this.actualFileName : regexArray[1]),
+                line: parseInt(regexArray[2]) - 1,
+                column: parseInt(regexArray[3]) - 1,
                 severity: this.getSeverityCode(regexArray[4]),
                 code: 0,
-                message: this.messages.join("\n\n"),
+                message: regexArray[5],
                 source: 'Clang',
             };
-
-            // reset; we used all values
-            this.resetParser();
-
             // return the resulting diagnostic
             return result;
         } else {


### PR DESCRIPTION
Hi Joe,

I'm not a JavaScript guru, I've been working with C++ projects for a long time...
So, according to your comment in the ticket I've created [HERE](https://github.com/jbenden/vscode-c-cpp-flylint/issues/14) - I've just quickly made this extension work correctly with the nested files issues-reports. Now all the issues from all the nested files are properly reported, and they all lead to proper places in related files after clicking them.

I'm not sure if I've done everything correctly from the JavaScript coding point of view, so I hope you'll have a look and use this as some ground to fix this issue...
Just in case: I'm in New Zealand, it's UTC+13 time zone here...

Thank you for a great extension, Joe!

Regards,
Jim