### PR TITLE
Addon support for cppcheck

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -370,6 +370,11 @@
           "default": [],
           "description": "Warnings to suppress. Refer to the CppCheck documentation for what to supply here."
         },
+        "c-cpp-flylint.cppcheck.addons": {
+          "type": "array",
+          "default": [],
+          "description": "Addons to use with cppcheck. For example, misra, cert, etc. Refer to the CppCheck documentation for what to supply here."
+        },
         "c-cpp-flylint.cppcheck.verbose": {
           "type": "boolean",
           "default": false,

--- a/server/src/linters/cppcheck.ts
+++ b/server/src/linters/cppcheck.ts
@@ -23,6 +23,7 @@ export class CppCheck extends Linter {
         let enableParams = this.settings['c-cpp-flylint'].cppcheck.unusedFunctions
                             ? [ '--enable=warning,style,performance,portability,information,unusedFunction' ]
                             : [ '--enable=warning,style,performance,portability,information' ];
+        let addonParams = this.getAddonParams();
         let includeParams = this.getIncludePathParams();
         let suppressionParams = this.getSuppressionParams();
         let languageParam = this.getLanguageParam();
@@ -46,6 +47,7 @@ export class CppCheck extends Linter {
         let args = [ this.executable ]
             .concat(['--inline-suppr'])
             .concat(enableParams)
+            .concat(addonParams)
             .concat(includeParams)
             .concat(standardParams)
             .concat(defineParams)
@@ -145,6 +147,19 @@ export class CppCheck extends Linter {
 
         if (this.isValidLanguage(language)) {
             params.push(`--language=${language}`);
+        }
+
+        return params;
+    }
+
+    private getAddonParams() {
+        let addons = this.settings['c-cpp-flylint'].cppcheck.addons;
+        let params: string[] = [];
+
+        if (addons) {
+            _.each(addons, (element: string) => {
+                params.push(`--addon=${element}`);
+            });
         }
 
         return params;

--- a/server/src/linters/tests/cppcheck.test.ts
+++ b/server/src/linters/tests/cppcheck.test.ts
@@ -123,4 +123,59 @@ class CppCheckTests {
         result.should.have.property('code', "unusedStructMember");
         expect(result['message']).to.match(/^struct member \'Anonymous5::name_space\' is never used\./);
     }
+
+    @test("Should handle output from misra addon")
+    handleMisra() {
+        let test = [
+            'Defines: CURRENT_DEVICE_VERSION=1;BIG_VERSION=1;LITTLE_VERSION=1;CURRENT_DEVICE_GROUP=1;CURRENT_DEVICE_SLEEP_TYPE=1;CURRENT_ABILITY_1BYTE=1;CURRENT_ABILITY_2BYTE=1;CURRENT_ABILITY_3BYTE=1;CURRENT_ABILITY_4BYTE=1;CLASS=1;CLASS_B=1;CLASS_C=1;IF_UD_RELAY=1;PRIu32="u";PRIx32="x";PRIX32="X";PRIXX32="X";NETSTACK_CONF_WITH_IPV6=1',
+            'Includes: -I/Users/username/Documents/Unwired/contiki_ud_ng/ -I/Users/username/Documents/Unwired/contiki_ud_ng/lib/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/dev/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/sys/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/net/ip/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/net/ipv6/ -I/Users/username/Documents/Unwired/contiki_ud_ng/unwired/ -I/Users/username/Documents/Unwired/contiki_ud_ng/unwired/asuno-light/ -I/Users/username/Documents/Unwired/contiki_ud_ng/unwired/smarthome/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/common/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/udboards/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/udboards/cc26xx/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/udboards/cc13xx/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/dev/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc26xxware/driverlib/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc13xxware/driverlib/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc13xxware/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc26xxware/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc13xxware/inc/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc26xxware/inc/ -I/Users/username/Documents/Unwired/contiki_ud_ng/apps/serial-shell/ -I/Users/username/Documents/Unwired/contiki_ud_ng/apps/shell/ -I/usr/local/lib/gcc/arm-none-eabi/6.2.1/include/',
+            'Platform:Native',
+            `"Checking flist.c ..."`,
+            `"flist.c  9  style misra-c2012-10.4: misra violation (use --rule-texts=<file> to get proper output)"`,
+            `"flist.c  11  style misra-c2012-17.7: misra violation (use --rule-texts=<file> to get proper output)"`,
+            `"flist.c  20  style misra-c2012-18.8: misra violation (use --rule-texts=<file> to get proper output)"`,
+            `"flist.c  1  style misra-c2012-21.6: misra violation (use --rule-texts=<file> to get proper output)"`,    
+            `"    information missingIncludeSystem: Cppcheck cannot find all the include files (use --check-config for details)"`,
+            `"    information missingInclude: Cppcheck cannot find all the include files (use --check-config for details)"`,
+        ];
+        let actual = this.linter['parseLines'](test);
+
+        actual.should.have.length(4);
+
+        let result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 1 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Information');
+        result.should.have.property('code', "misra-c2012-21.6");
+        expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
+
+        result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 20 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Information');
+        result.should.have.property('code', "misra-c2012-18.8");
+        expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
+
+        result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 11 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Information');
+        result.should.have.property('code', "misra-c2012-17.7");
+        expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
+
+        result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 9 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Information');
+        result.should.have.property('code', "misra-c2012-10.4");
+        expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
+    }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -353,7 +353,21 @@ async function validateTextDocument(textDocument: TextDocument, lintOn: Lint) {
                         result.splice(i, 1);
                     }
 
+                    const misraDiagnostics:Diagnostic[] = [];
+                    if (settings['c-cpp-flylint'].cppcheck.addons.includes("misra")) {
+                        diagnostics.forEach(diagnostic => {
+                            if (diagnostic.message.includes('misra')) {
+                                misraDiagnostics.push(diagnostic);
+                            }
+                        })
+                    }
                     diagnostics = _.uniqBy(diagnostics, function (e) { return e.line + ":::" + e.message; } );
+
+                    if (settings['c-cpp-flylint'].cppcheck.addons.includes("misra")) {
+                        misraDiagnostics.forEach(misraDiagnostic => {
+                            diagnostics.push(misraDiagnostic)
+                        })
+                    }
 
                     if (allDiagnostics.hasOwnProperty(currentFile)) {
                         allDiagnostics[currentFile] = _.union(allDiagnostics[currentFile], diagnostics);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -353,21 +353,7 @@ async function validateTextDocument(textDocument: TextDocument, lintOn: Lint) {
                         result.splice(i, 1);
                     }
 
-                    const misraDiagnostics:Diagnostic[] = [];
-                    if (settings['c-cpp-flylint'].cppcheck.addons.includes("misra")) {
-                        diagnostics.forEach(diagnostic => {
-                            if (diagnostic.message.includes('misra')) {
-                                misraDiagnostics.push(diagnostic);
-                            }
-                        })
-                    }
-                    diagnostics = _.uniqBy(diagnostics, function (e) { return e.line + ":::" + e.message; } );
-
-                    if (settings['c-cpp-flylint'].cppcheck.addons.includes("misra")) {
-                        misraDiagnostics.forEach(misraDiagnostic => {
-                            diagnostics.push(misraDiagnostic)
-                        })
-                    }
+                    diagnostics = _.uniqBy(diagnostics, function (e) { return e.code + ":::" + e.message; } );
 
                     if (allDiagnostics.hasOwnProperty(currentFile)) {
                         allDiagnostics[currentFile] = _.union(allDiagnostics[currentFile], diagnostics);

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -84,6 +84,7 @@ export interface Settings {
             defines: string[] | null;
             undefines: string[] | null;
             suppressions: string[];
+            addons: string[];
             language: "c" | "c++" | null;
             severityLevels: CppCheckSeverityMaps;
         }


### PR DESCRIPTION
You can now pass cppcheck addons to this extension which are used for producing even more lint errors. Some slight modifications how unique diagnostic messages are handled when the error comes from the misra addon. This is because the addon produces identical messages for each violation, but does have unique codes. The misra addon does not provide the actual error but only the error code and you need to own the misra guidelines to actually know the rule violation.

The work here could be extented to handle #66.