### PR TITLE
Multiple violations of the same type not displayed

### DIFF
--- a/server/src/linters/tests/cppcheck.test.ts
+++ b/server/src/linters/tests/cppcheck.test.ts
@@ -178,4 +178,59 @@ class CppCheckTests {
         result.should.have.property('code', "misra-c2012-10.4");
         expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
     }
+
+    @test("Should find identical errors on different lines")
+    handleIdenticalErrors() {
+        let test = [
+            'Defines: CURRENT_DEVICE_VERSION=1;BIG_VERSION=1;LITTLE_VERSION=1;CURRENT_DEVICE_GROUP=1;CURRENT_DEVICE_SLEEP_TYPE=1;CURRENT_ABILITY_1BYTE=1;CURRENT_ABILITY_2BYTE=1;CURRENT_ABILITY_3BYTE=1;CURRENT_ABILITY_4BYTE=1;CLASS=1;CLASS_B=1;CLASS_C=1;IF_UD_RELAY=1;PRIu32="u";PRIx32="x";PRIX32="X";PRIXX32="X";NETSTACK_CONF_WITH_IPV6=1',
+            'Includes: -I/Users/username/Documents/Unwired/contiki_ud_ng/ -I/Users/username/Documents/Unwired/contiki_ud_ng/lib/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/dev/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/sys/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/net/ip/ -I/Users/username/Documents/Unwired/contiki_ud_ng/core/net/ipv6/ -I/Users/username/Documents/Unwired/contiki_ud_ng/unwired/ -I/Users/username/Documents/Unwired/contiki_ud_ng/unwired/asuno-light/ -I/Users/username/Documents/Unwired/contiki_ud_ng/unwired/smarthome/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/common/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/udboards/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/udboards/cc26xx/ -I/Users/username/Documents/Unwired/contiki_ud_ng/platform/unwired/udboards/cc13xx/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/dev/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc26xxware/driverlib/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc13xxware/driverlib/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc13xxware/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc26xxware/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc13xxware/inc/ -I/Users/username/Documents/Unwired/contiki_ud_ng/cpu/cc26xx-cc13xx/lib/cc26xxware/inc/ -I/Users/username/Documents/Unwired/contiki_ud_ng/apps/serial-shell/ -I/Users/username/Documents/Unwired/contiki_ud_ng/apps/shell/ -I/usr/local/lib/gcc/arm-none-eabi/6.2.1/include/',
+            'Platform:Native',
+            `"Checking flist.c ..."`,
+            `"flist.c  9  error zerodiv: Division by zero"`,
+            `"flist.c  23  error zerodiv: Division by zero"`,
+            `"flist.c  15  style misra-c2012-10.4: misra violation (use --rule-texts=<file> to get proper output)"`,
+            `"flist.c  36  style misra-c2012-10.4: misra violation (use --rule-texts=<file> to get proper output)"`,
+            `"    information missingIncludeSystem: Cppcheck cannot find all the include files (use --check-config for details)"`,
+            `"    information missingInclude: Cppcheck cannot find all the include files (use --check-config for details)"`,
+        ];
+        let actual = this.linter['parseLines'](test);
+
+        actual.should.have.length(4);
+
+        let result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 36 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Information');
+        result.should.have.property('code', "misra-c2012-10.4");
+        expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
+
+        result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 15 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Information');
+        result.should.have.property('code', "misra-c2012-10.4");
+        expect(result['message']).to.equal('misra violation (use --rule-texts=<file> to get proper output)');
+
+        result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 23 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Error');
+        result.should.have.property('code', "zerodiv");
+        expect(result['message']).to.equal('Division by zero');
+
+        result = actual.pop();
+
+        result.should.have.property('fileName', 'flist.c');
+        result.should.have.property('line', 9 - 1);
+        result.should.have.property('column', 0);
+        result.should.have.property('severity', 'Error');
+        result.should.have.property('code', "zerodiv");
+        expect(result['message']).to.equal('Division by zero');
+    }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -357,7 +357,7 @@ async function validateTextDocument(textDocument: TextDocument, lintOn: Lint) {
                         result.splice(i, 1);
                     }
 
-                    diagnostics = _.uniqBy(diagnostics, function (e) { return e.code + ":::" + e.message; } );
+                    diagnostics = _.uniqBy(diagnostics, function (e) { return e.range.start.line + ":::" + e.code + ":::" + e.message; } );
 
                     if (allDiagnostics.hasOwnProperty(currentFile)) {
                         allDiagnostics[currentFile] = _.union(allDiagnostics[currentFile], diagnostics);


### PR DESCRIPTION
This pull request is intended as a bug fix.

The linter was not able to display violations of the same type that appeared on different lines. This commit contains a fix for this as well as a unit test for this scenario. The problem, however, is that the unit test will not detect this error since, in the test scope, the output has not passed through the uniqBy filtering. If I am not being clear with that type of cppcheck output that results in buggy behaviour, the unit test shows the scenario clearly.

The fix to this problem was to "re-add" the line check to the lambda in uniqBy. However, this time it is done with e.range.start.line instead of e.line. e.range.start.line is a field that exists and carries the line correctly.

This commit solves the problem. However, without the fix, the unit test would still pass, since the problem is in the layer where data is being pushed to VSCode. 