### PR TITLE
cppcheck: add 'extraArgs' argument

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -314,6 +314,14 @@
           "description": "This option allows you to override the executable called when using CppCheck",
           "default": "cppcheck"
         },
+        "c-cpp-flylint.cppcheck.extraArgs": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "description": "Extra verbatim command-line arguments to include on the cppcheck command-line invocation."
+        },
         "c-cpp-flylint.cppcheck.configFile": {
           "type": "string",
           "description": "A .clang_complete file to use/fallback to if no config file is found in the current project",

--- a/server/src/linters/cppcheck.ts
+++ b/server/src/linters/cppcheck.ts
@@ -55,7 +55,8 @@ export class CppCheck extends Linter {
             .concat(suppressionParams)
             .concat(languageParam)
             .concat([platformParams])
-            .concat([`--template="{file}  {line}  {severity} {id}: {message}"`]);
+            .concat([`--template="{file}  {line}  {severity} {id}: {message}"`])
+            .concat(this.settings['c-cpp-flylint'].cppcheck.extraArgs || []);
 
         if (this.settings['c-cpp-flylint'].cppcheck.verbose === true) {
             args.push('--verbose');

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -87,6 +87,7 @@ export interface Settings {
             addons: string[];
             language: "c" | "c++" | null;
             severityLevels: CppCheckSeverityMaps;
+            extraArgs: string[] | null;
         }
         clang: {
             enable: boolean;


### PR DESCRIPTION
Closes #76 

Let users pass extra command line arguments to cppcheck via the
'extraArgs' setting in the client.

Works the same as 'extraArgs' for clang.

This is helpful so users can specify other options that the
settings does not cover, such as "--project", in order to
point cppcheck to a compilation database and "-j", in order
to invoke cppcheck with multiple jobs.

Signed-off-by: Daniel W. S. Almeida <dwlsalmeida@gmail.com>