### PR TITLE
Allow diagnostic code lookup on the web

### DIFF
--- a/client/src/flylintLanguageClient.ts
+++ b/client/src/flylintLanguageClient.ts
@@ -1,0 +1,34 @@
+import {LanguageClient, LanguageClientOptions, ServerOptions} from 'vscode-languageclient/node';
+import * as ls from 'vscode-languageserver';
+import * as code from 'vscode';
+
+export class FlylintLanguageClient extends LanguageClient {
+    constructor(
+        id: string,
+        name: string,
+        serverOptions: ServerOptions,
+        clientOptions: LanguageClientOptions,
+        queryUrlStr: string,
+        matchSet: string[],
+        forceDebug?: boolean
+    ) {
+        super(id, name, serverOptions, clientOptions, forceDebug);
+        let originalAsDiagnostic = this.protocol2CodeConverter.asDiagnostic;
+        this.protocol2CodeConverter.asDiagnostic = ((diagnostic: ls.Diagnostic): code.Diagnostic => {
+            let result = originalAsDiagnostic(diagnostic);
+            if ((result.code !== undefined) && (typeof result.code === 'string') && (queryUrlStr.length > 0)) {
+                let codeStr = String(result.code);
+                if (matchSet.some(v => codeStr.includes(v))) {
+                    result.code = {
+                        value: result.code,
+                        target: this.protocol2CodeConverter.asUri(`${queryUrlStr}${result.source}%20${result.code}`)
+                    };
+                }
+            }
+            return result;
+        });
+        this.protocol2CodeConverter.asDiagnostics = ((diagnostics: ls.Diagnostic[]): code.Diagnostic[] => {
+            return diagnostics.map(this.protocol2CodeConverter.asDiagnostic);
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -204,6 +204,19 @@
           "default": [],
           "description": "Paths to search for include files. They may be relative or absolute. Cascades to all analyzers unless overridden in one or more analyzers. If not specified it uses \"C_Cpp.default.includePath\" or \"includePath\" from c_cpp_properties.json"
         },
+        "c-cpp-flylint.queryUrlBase": {
+          "type": "string",
+          "format": "uri",
+          "markdownDescription": "This option allows you to chose your preferred search engine for diagnostic code lookup. See also `#c-cpp-flylint.webQueryMatchSet#` to configure the keywords of the diagnostic code which will make it searchable on the web.",
+          "default": "https://www.google.com/search?q="
+        },
+        "c-cpp-flylint.webQueryMatchSet": {
+          "type": "array",
+          "default": [
+            "misra-"
+          ],
+          "markdownDescription": "The diagnostic code match set for which a web lookup will be proposed. Web search engine can be customized through `#c-cpp-flylint.queryUrlBase#`."
+        },
         "c-cpp-flylint.clang.enable": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
In some cases, like for misra rule checking with CppCheck, no useful
description is available from the tool. This change introduces the
ability to search the diagnostic code on the web for more information.
The query base Uri and the set of words to match to activate the
behavior are configurable through settings. For security reasons, the
query base Uri is only configurable from trusted workspaces.
The feature also only activates when the language server doesn't
already provide a link in the generated diagnostic.