### PR TITLE
Supports c_cpp_properties.json by Platformio

### DIFF
--- a/server/src/linters/linter.ts
+++ b/server/src/linters/linter.ts
@@ -400,6 +400,9 @@ export class Linter {
 
         if (values) {
             _.each(values, (element: string) => {
+                if (element === '') {
+                    return;
+                }
                 let value = this.expandVariables(element);
                 if (value.error) {
                     console.log(`Error expanding '${element}': ${value.error.message}`);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -225,7 +225,8 @@ export async function getCppProperties(cCppPropertiesPath: string, currentSettin
     try {
         if (fs.existsSync(cCppPropertiesPath)) {
             const matchOn: string = await getActiveConfigurationName(currentSettings);
-            const cCppProperties: IConfigurations = JSON.parse(fs.readFileSync(cCppPropertiesPath, 'utf8'));
+            const JSON5 = require('json5');
+            const cCppProperties: IConfigurations = JSON5.parse((fs.readFileSync(cCppPropertiesPath, 'utf8')));
             const platformConfig = cCppProperties.configurations.find(el => el.name === matchOn);
 
             if (platformConfig !== undefined) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -236,6 +236,10 @@ export async function getCppProperties(cCppPropertiesPath: string, currentSettin
                     process.env.workspaceFolder = workspaceRoot;
 
                     _.forEach(platformConfig.includePath, (ipath: string) => {
+                        //skip empty paths
+                        if (ipath === '') {
+                            return;
+                        }
                         try {
                             let { value } = substituteVariables(ipath, { env: process.env });
                             let globbed_path = glob.sync(value, { cwd: workspaceRoot, dot: false, onlyDirectories: true, unique: true, absolute: true });


### PR DESCRIPTION
Solves [issues](https://github.com/jbenden/vscode-c-cpp-flylint/issues/164) with c_cpp_properties.json that contains comments and empty paths. 

Now paths are added correctly and those that are empty don't cause errors in Debug console.