### PR TITLE
lizard: add 'extraArgs' argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -871,6 +871,14 @@
           "type": "string",
           "description": "This option allows you to override the executable called when using lizard",
           "default": "lizard"
+        },
+        "c-cpp-flylint.lizard.extraArgs": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "description": "Extra verbatim command-line arguments to include on the lizard command-line invocation."
         }
       }
     }

--- a/server/src/linters/lizard.ts
+++ b/server/src/linters/lizard.ts
@@ -15,7 +15,7 @@ export class Lizard extends Linter {
     protected buildCommandLine(fileName: string, _tmpFileName: string): string[] {
         let args = [this.executable]
             .concat(['--warnings_only'])
-            .concat([]);
+            .concat(this.settings['c-cpp-flylint'].lizard.extraArgs || []);
 
         args.push(fileName);
 

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -166,6 +166,7 @@ export interface FlylintSettings {
     lizard: {
         enable: boolean;
         executable: string;
+        extraArgs: string[] | null;
     }
 }
 

--- a/specs/mock-config.ts
+++ b/specs/mock-config.ts
@@ -131,7 +131,8 @@ export const defaultConfig: Settings = {
 
         lizard: {
             enable: true,
-            executable: 'lizard'
+            executable: 'lizard',
+            extraArgs: null,
         }
     }
 };


### PR DESCRIPTION
Let users pass extra command line arguments to lizard via the 'extraArgs' setting in the client.
Works the same as 'extraArgs' for clang.