### PR TITLE
Add support for pclint plus 2.0 version trial version license

### DIFF
--- a/server/src/linters/pclintplus.ts
+++ b/server/src/linters/pclintplus.ts
@@ -61,7 +61,7 @@ export class PclintPlus extends Linter {
         let regex = /^(([^ ]+)?\s\s([0-9]+)\s([0-9]+\s)?\s([iI]nfo|[wW]arning|[eE]rror|[nN]ote|[sS]upplemental)\s([0-9]+):\s(.*)|(.+?):([0-9]+):([0-9]+:)?\s([iI]nfo|[wW]arning|[eE]rror|[nN]ote|[sS]upplemental)\s([0-9]+):\s(.*))$/;
         let regexArray: RegExpExecArray | null;
 
-        let excludeRegex = /^(\s+file '.*'|[^ \t]+|)$/;
+        let excludeRegex = /^(\s+file '.*'|PC-lint.*|licensed.*|LICENSED.*|.*evaluation license.*|[^ \t]+|)$/;
         if (excludeRegex.exec(line) !== null) {
             // skip this line
             return null;


### PR DESCRIPTION
I'm not sure if the official version of the license has this output, but when I use the trial version license, I get a similar output:

```
PC-lint Plus 2.0 for Windows, Copyright Vector Informatik GmbH 1985-2022
LICENSED FOR EVALUATION USE ONLY -- NOT FOR PRODUCTION
licensed for evaluation to xxxx@mailto.plus
14-jan-2024, evaluation license expires 22-jan-2024 (4 days)
```

So I need to filter this output by code