### PR TITLE
json5 import 

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { parse as jsonParse } from 'json5';
+const JSON5 = require('json5').default;
+
 import {
     Connection,
     createConnection,
@@ -244,7 +245,7 @@ export async function getCppProperties(cCppPropertiesPath: string, currentSettin
     try {
         if (fs.existsSync(cCppPropertiesPath)) {
             const matchOn: string = await getActiveConfigurationName(currentSettings[FLYLINT_ID]);
-            const cCppProperties: IConfigurations = jsonParse((fs.readFileSync(cCppPropertiesPath, 'utf8')));
+            const cCppProperties: IConfigurations = JSON5.parse((fs.readFileSync(cCppPropertiesPath, 'utf8')));
             const platformConfig = cCppProperties.configurations.find(el => el.name === matchOn);
 
             if (platformConfig !== undefined) {


### PR DESCRIPTION
This `.default` attribute somehow fixes `TypeError: n(...).parse is not a function` errors https://github.com/jbenden/vscode-c-cpp-flylint/issues/180

The change was inspired by https://github.com/node-config/node-config/issues/755#issuecomment-1886617466 - I don't know how any of this works. 

I verified that json5 parser is indeed used with this, because it parses a `c_cpp_properties.json` that has comments generated by Platformio. 
